### PR TITLE
Markdown and RestructuredText improvements

### DIFF
--- a/lua/zenburn/highlights/render-markdown.lua
+++ b/lua/zenburn/highlights/render-markdown.lua
@@ -2,12 +2,12 @@ local c = require("zenburn.palette")
 return {
   RenderMarkdownCodeInline = { bg="none" },
 
-  -- Colors for markdown heading backgrounds (when not in insert mode)
-  RenderMarkdownH1Bg = { underline=true, },
-  RenderMarkdownH2Bg = { underline=true, },
-  RenderMarkdownH3Bg = { underline=true, },
-  RenderMarkdownH4Bg = { underline=true, },
-  RenderMarkdownH5Bg = { underline=true, },
+  -- Don't change background of headings
+  RenderMarkdownH1Bg = { },
+  RenderMarkdownH2Bg = { },
+  RenderMarkdownH3Bg = { },
+  RenderMarkdownH4Bg = { },
+  RenderMarkdownH5Bg = { },
 
   -- Don't change the foreground text
   RenderMarkdownH1 = { },

--- a/lua/zenburn/highlights/treesitter.lua
+++ b/lua/zenburn/highlights/treesitter.lua
@@ -67,6 +67,13 @@ return {
   ["@markup.heading"] = {fg=c.Keyword.fg, bold=true},
   ["@markup.strong.markdown_inline"] = { fg=c.Question.fg,  bold=true},
   ["@markup.italic.markdown_inline"] = { italic=true },
+  ["@function.rst"] = { fg=c.Boolean.fg, },
+  ["@function.builtin.rst"] = { fg=c.Boolean.fg, },
+  ["@markup.link.rst"] = {fg=c.Label.fg, underline=true},
+  ["@constant.rst"] = { fg=c.Conditional.fg },
+  ["@markup.link.label.rst"] = {fg=c.StorageClass.fg, italic=true},
+  ["@markup.raw.rst"] = { fg = c.String.fg }, 
+  ["@variable.parameter.rst"] = { fg = c.Delimiter.fg },
 }
 -- TSAttribute
 -- TSBoolean


### PR DESCRIPTION
- don't use underline for markdown headings
- add some highlight groups for restructuredtext treesitter highlights